### PR TITLE
Add libc6-compat for snappy shared library dependency of ld-linux-x86-64.so.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH $PATH:$KAFKA_HOME/bin
 RUN mkdir /opt
 
 # Dependencies
-RUN apk add --no-cache supervisor bash jq
+RUN apk add --no-cache supervisor bash jq libc6-compat
 
 # Kafka
 RUN wget -q -O - $(wget -q -O - "http://www.apache.org/dyn/closer.cgi?as_json=1" | jq -r .preferred)/kafka/$KAFKA_VERSION/kafka_$SCALA_VERSION-$KAFKA_VERSION.tgz | \


### PR DESCRIPTION
This fixes an issue where snappy can't find a dependent shared library, solves the following error when writing to kafka with snappy compression.

`java.lang.UnsatisfiedLinkError: /tmp/snappy-unknown-c9a889a6-aaa0-4dea-9641-dd02710d2711-libsnappyjava.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /tmp/snappy-unknown-c9a889a6-aaa0-4dea-9641-dd02710d2711-libsnappyjava.so)`
